### PR TITLE
feat(DeadLinks): add config override for resolving custom link markDefs

### DIFF
--- a/src/utils/guards.ts
+++ b/src/utils/guards.ts
@@ -6,6 +6,7 @@ type PortableTextLink = {
   href: string
 }
 
+export type LinkKeys<K extends object> = (keyof K)[]
 export const isPortableTextLink = (mark: PortableTextObject): mark is PortableTextLink => {
   return Boolean(mark._type === 'link' && 'href' in mark)
 }


### PR DESCRIPTION
This PR proposes customisation for the DeadLinks plugin to solve #2 

## Example usage
Simple override
```typescript
Preflight({
  plugins: [
    DeadLinks({
      content: "content",
      overrideLinkKeys: ["url", "href"],
    }),
  ],
})
```
A slightly more advanced override
```typescript
// these types could be generated with sanity typegen generate
type MyExternalLinkType = {
  url: string;
  target: string;
}

type MyProductLinkType = {
  fullUrl: string;
  showOnHover?: boolean;
}

type MyCustomLinkType = {
  hrefForAdmin: string;
  hrefForGuest: string;
}

Preflight({
  plugins: [
    DeadLinks<MyExternalLinkType | MyProductLinkType | MyCustomLinkType>({
      content: "content",
      overrideLinkKeys: ["url", "fullUrl", "hrefForGuest"], // typescript will only allow keys of the generics above
    }),
  ],
})
```

## Questions
- Should this directly support doing `typescript typeof mySchemaType`? This adds a lot more complexity that at first thought may fall outside the scope of library, but admittedly a nice DX.
- Are there any other ways links could be embedded in portable text that this proposed override would not pick up?
- How should an example be portrayed in the README.md?